### PR TITLE
Fix `run` functionality for Deis provider

### DIFF
--- a/lib/dpl/provider/deis.rb
+++ b/lib/dpl/provider/deis.rb
@@ -102,7 +102,7 @@ module DPL
       end
 
       def run(command)
-        unless context.shell "deis run -- #{command}"
+        unless context.shell "./deis run -- #{command}"
           error 'Running command failed.'
         end
       end


### PR DESCRIPTION
Hi there! I'm not sure if this is v2 specific, since I don't have a v1 service to test it out on, but it seems like the `run` functionality is currently broken. This is what I got while running on your v2 branch (thanks for putting that together, BTW!):

```
Running "bundle exec rake db:{migrate,seed}"
sh: 1: deis: not found
```

Adding a `./` like in the other deis calls in the provider fixed it for me. It would be awesome to get this included in your Deis v2 PR https://github.com/travis-ci/dpl/pull/440.
